### PR TITLE
Add CLUSTERPOOL_MIN_SIZE setting (replace RESIZE/MAX_CLUSTERS)

### DIFF
--- a/utils/config.sh.template
+++ b/utils/config.sh.template
@@ -18,8 +18,7 @@ export AUTH_REDIRECT_PATHS=""
 # ClusterClaim exports
 export CLUSTERPOOL_TARGET_NAMESPACE="" # Your namespace on the collective cluster
 export CLUSTERPOOL_NAME="" # Name of the ClusterPool to use
-export CLUSTERPOOL_RESIZE="" # Set to "true" to allow resizing of the pool if all clusters have been claimed (CLUSTERPOOL_TARGET_NAMESPACE and CLUSTERPOOL_NAME must both be specified for this to work)
-export CLUSTERPOOL_MAX_CLUSTERS="" # Maximum clusters to allow in the ClusterPool if CLUSTERPOOL_RESIZE is enabled)
+export CLUSTERPOOL_MIN_SIZE="" # Set a minimum size to allow resizing of the pool if it does not meet the minimum
 export CLUSTERCLAIM_NAME="" # Name of the ClusterClaim to create
 export CLUSTERCLAIM_GROUP_NAME="" # RBAC group in cluster (also used for labeling--should match GitHub team)
 export CLUSTERCLAIM_END_TIME="" # Integer hour in 24h clock at which to expire the cluster

--- a/utils/config.sh.template-grc
+++ b/utils/config.sh.template-grc
@@ -16,7 +16,7 @@ export AUTH_REDIRECT_PATHS="/ /policies/ /header/ /topology/"
 # ClusterClaim exports
 export CLUSTERPOOL_TARGET_NAMESPACE="acm-grc-security"
 export CLUSTERPOOL_NAME="${GROUP_NAME}-cp-dev"
-export CLUSTERPOOL_RESIZE="true"
+export CLUSTERPOOL_MIN_SIZE="1"
 export CLUSTERCLAIM_NAME="${CLUSTERPOOL_USER}-${CLUSTERPOOL_NAME}"
 export CLUSTERCLAIM_GROUP_NAME=${GROUP_NAME}
 export CLUSTERCLAIM_END_TIME="18"


### PR DESCRIPTION
Allows specification of a minimum size for the ClusterPool. User customizable in case they intend to run multiple copies of startrhacm at the same time of day, so a size greater than 1 could be specified so that Hive prepares clusters in parallel.