### PR TITLE
Fix start konflux script to overwrite quay.io:443 token if exists already in openshift-config pull-secret

### DIFF
--- a/start-konflux.sh
+++ b/start-konflux.sh
@@ -60,7 +60,7 @@ printlog info "Updating Openshift pull-secret in namespace openshift-config with
 QUAY443_TOKEN=$(echo "${QUAY_TOKEN}" | base64 --decode | sed "s/quay\.io/quay\.io:443/g")
 OPENSHIFT_PULL_SECRET=$(oc get -n openshift-config secret pull-secret -o jsonpath='{.data.\.dockerconfigjson}' | base64 --decode)
 FULL_TOKEN="${QUAY443_TOKEN}${OPENSHIFT_PULL_SECRET}"
-oc set data secret/pull-secret -n openshift-config --from-literal=.dockerconfigjson="$(jq -s '.[0] * .[1]' <<<"${FULL_TOKEN}")"
+oc set data secret/pull-secret -n openshift-config --from-literal=.dockerconfigjson="$(jq -s '.[1] * .[0]' <<<"${FULL_TOKEN}")"
 
 printlog info "Applying ImageDigestMirrorSet"
 oc apply -f - <<EOF


### PR DESCRIPTION
This reverses the jq slurp order. jq will give the first item (0) precedence over the 2nd item (1). If "quay.io:443" already exists in openshift-config pull-secret, it will keep that and not overwrite with the one provided in QUAY_TOKEN var. I think it is better to overwrite, since script expects that QUAY_TOKEN is set, which implies this value will get used.

In my case, I have "quay.io:443" already set in the pull secret, and it is a wrong value! So that is how I noticed this edge case.